### PR TITLE
Memory leak optimization

### DIFF
--- a/libminipng/Classes/minipng.c
+++ b/libminipng/Classes/minipng.c
@@ -78,6 +78,7 @@ unsigned long _data2Data(unsigned char **data,int maximum,unsigned char* png_dat
     liq_attr_destroy(handle);
     free(png_data);
     free(raw_8bit_pixels);
+    free(raw_rgba_pixels);
     lodepng_state_cleanup(&state);
     return output_file_size;
 }


### PR DESCRIPTION
In minipng.c file there is a pointer declared as "raw_rgba_pixels" in _data2Data function, but when the process is finished memory was not cleared for that and for this memory leak was happening. By freeing the pointer memory the leak is not seen anymore. 